### PR TITLE
Continuous integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install poetry
-        poetry install --no-root
+        poetry install
     - name: Check style
       run: poetry run flake8 --exclude=docs*
     - name: Test with pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Miro (Shangjing) HU <mirohu@outlook.com>"]
 license = "MIT"
 packages = [
-    { include = "PackageName"},
+    { include = "PyDataPeek"},
 ]
 readme = "README.md"
 homepage = "https://github.com/UBC-MDS/PyDataPeek"


### PR DESCRIPTION
FINALLY fixed issue that was causing us to use `poetry install --no-root`